### PR TITLE
FOUNDATIONS: Support for Aggregate Exceptions on fluent assertion and SameExceptionAs overload

### DIFF
--- a/Xeption.Infrastructure.Build/Program.cs
+++ b/Xeption.Infrastructure.Build/Program.cs
@@ -99,7 +99,7 @@ namespace Xeptions.Infrastructure.Build
             string buildScriptPath = "../../../../.github/workflows/dotnet.yml";
             string directoryPath = Path.GetDirectoryName(buildScriptPath);
 
-            if (!Directory.Exists(directoryPath))
+            if (Directory.Exists(directoryPath) is false)
             {
                 Directory.CreateDirectory(directoryPath);
             }

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -68,6 +68,28 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
+        [Fact(DisplayName = "03.2 - BeEquivalentToShouldFailIfExceptionMessagesDontMatch")]
+        public void BeEquivalentToShouldFailIfExceptionMessagesDontMatch()
+        {
+            // given
+            var expectedException = new Xeption(message: GetRandomString());
+            var actualException = new Xeption(message: GetRandomString());
+
+            string expectedMessage =
+                $"Expected exception message to be \"{expectedException.Message}\", " +
+                $"but found \"{actualException.Message}\"";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
+        }
+
         // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using FluentAssertions;
 using Force.DeepCloner;
 using Xunit;
@@ -113,23 +114,27 @@ namespace Xeptions.Tests
         {
             // given
             string exceptionMessage = GetRandomString();
-            string mutualKey = GetRandomString();
+            string mutualKey = $"mutual-{GetRandomString()}";
             KeyValuePair<string, List<string>> expectedDataOne = GenerateKeyValuePair(count: 1);
             KeyValuePair<string, List<string>> expectedDataTwo = GenerateKeyValuePair(count: 1);
             KeyValuePair<string, List<string>> actualData = GenerateKeyValuePair(count: 1);
-            KeyValuePair<string, List<string>> expectedDataSameKeyName = GenerateKeyValuePair(count: 1, mutualKey);
-            KeyValuePair<string, List<string>> actualDataSameKeyName = GenerateKeyValuePair(count: 1, mutualKey);
+
+            KeyValuePair<string, List<string>> expectedDataSameKeyName =
+                GenerateKeyValuePair(count: 1, keyName: mutualKey);
+
+            KeyValuePair<string, List<string>> actualDataSameKeyName =
+                GenerateKeyValuePair(count: 1, keyName: mutualKey);
 
             var expectedException = new Xeption(
                 message: exceptionMessage);
 
             expectedException.AddData(
-                key: expectedDataTwo.Key,
-                values: expectedDataTwo.Value.ToArray());
-
-            expectedException.AddData(
                 key: expectedDataOne.Key,
                 values: expectedDataOne.Value.ToArray());
+
+            expectedException.AddData(
+                key: expectedDataTwo.Key,
+                values: expectedDataTwo.Value.ToArray());
 
             expectedException.AddData(
                 key: expectedDataSameKeyName.Key,
@@ -139,32 +144,32 @@ namespace Xeptions.Tests
                 message: exceptionMessage);
 
             actualException.AddData(
-                key: actualData.Key,
-                values: actualData.Value.ToArray());
-
-            actualException.AddData(
                 key: actualDataSameKeyName.Key,
                 values: actualDataSameKeyName.Value.ToArray());
 
-            string titleMessage =
-                $"Expected exception with type '{expectedException.GetType().FullName}' " +
-                $"and message '{expectedException.Message}' to:";
+            actualException.AddData(
+                key: actualData.Key,
+                values: actualData.Value.ToArray());
 
-            string errorCountMessage =
+            StringBuilder expectedError = new StringBuilder();
+            expectedError.AppendLine($"Expected exception to:");
+
+            expectedError.AppendLine(
                 $"- have an expected data item count to be {expectedException.Data.Count}, " +
-                $"but found {actualException.Data.Count}.";
+                $"but found {actualException.Data.Count}.");
 
-            string messageOne =
-                $"- contain key '{expectedDataOne.Key}', but it was not found.";
+            expectedError.AppendLine(
+                $"- contain key '{expectedDataOne.Key}' with value(s) [{expectedDataOne.Value[0]}].");
 
-            string messageTwo =
-                $"- contain key '{expectedDataTwo.Key}', but it was not found.";
+            expectedError.AppendLine(
+                $"- contain key '{expectedDataTwo.Key}' with value(s) [{expectedDataTwo.Value[0]}].");
 
-            string messageThree =
-                $"- not contain key '{actualData.Key}'.";
+            expectedError.AppendLine(
+                $"- NOT contain key '{actualData.Key}'.");
 
-            string messageFour =
-                $"- not contain key '{actualData.Key}'.";
+            expectedError.AppendLine(
+                $"- have key '{mutualKey}' with value(s) [{expectedDataSameKeyName.Value[0]}], " +
+                $"but found value(s) [{actualDataSameKeyName.Value[0]}].");
 
             // when
             Action assertAction = () =>
@@ -174,11 +179,7 @@ namespace Xeptions.Tests
                 Assert.Throws<XunitException>(assertAction);
 
             //then
-            actualError.Message.Should().Contain(errorCountMessage);
-            actualError.Message.Should().Contain(messageOne);
-            actualError.Message.Should().Contain(messageTwo);
-            actualError.Message.Should().Contain(messageThree);
-            actualError.Message.Should().Contain(messageFour);
+            actualError.Message.Should().BeEquivalentTo(expectedError.ToString());
         }
 
         [Fact(DisplayName = "03.1 - BeEquivalentToShouldPassIfInnerExceptionsMatch")]
@@ -314,12 +315,12 @@ namespace Xeptions.Tests
                 message: exceptionMessage);
 
             expectedInnerException.AddData(
-                key: expectedDataTwo.Key,
-                values: expectedDataTwo.Value.ToArray());
-
-            expectedInnerException.AddData(
                 key: expectedDataOne.Key,
                 values: expectedDataOne.Value.ToArray());
+
+            expectedInnerException.AddData(
+                key: expectedDataTwo.Key,
+                values: expectedDataTwo.Value.ToArray());
 
             expectedInnerException.AddData(
                 key: expectedDataSameKeyName.Key,
@@ -329,32 +330,32 @@ namespace Xeptions.Tests
                 message: exceptionMessage);
 
             actualInnerException.AddData(
-                key: actualData.Key,
-                values: actualData.Value.ToArray());
-
-            actualInnerException.AddData(
                 key: actualDataSameKeyName.Key,
                 values: actualDataSameKeyName.Value.ToArray());
 
-            string titleMessage =
-                $"Expected exception with type '{expectedInnerException.GetType().FullName}' " +
-                $"and message '{expectedInnerException.Message}' to:";
+            actualInnerException.AddData(
+                key: actualData.Key,
+                values: actualData.Value.ToArray());
 
-            string errorCountMessage =
+            StringBuilder expectedError = new StringBuilder();
+            expectedError.AppendLine($"Expected inner exception to:");
+
+            expectedError.AppendLine(
                 $"- have an expected data item count to be {expectedInnerException.Data.Count}, " +
-                $"but found {actualInnerException.Data.Count}.";
+                $"but found {actualInnerException.Data.Count}.");
 
-            string messageOne =
-                $"- contain key '{expectedDataOne.Key}', but it was not found.";
+            expectedError.AppendLine(
+                $"- contain key '{expectedDataOne.Key}' with value(s) [{expectedDataOne.Value[0]}].");
 
-            string messageTwo =
-                $"- contain key '{expectedDataTwo.Key}', but it was not found.";
+            expectedError.AppendLine(
+                $"- contain key '{expectedDataTwo.Key}' with value(s) [{expectedDataTwo.Value[0]}].");
 
-            string messageThree =
-                $"- not contain key '{actualData.Key}'.";
+            expectedError.AppendLine(
+                $"- NOT contain key '{actualData.Key}'.");
 
-            string messageFour =
-                $"- not contain key '{actualData.Key}'.";
+            expectedError.AppendLine(
+                $"- have key '{mutualKey}' with value(s) [{expectedDataSameKeyName.Value[0]}], " +
+                $"but found value(s) [{actualDataSameKeyName.Value[0]}].");
 
             var expectedException = new Xeption(
                 message: exceptionMessage,
@@ -372,14 +373,8 @@ namespace Xeptions.Tests
                 Assert.Throws<XunitException>(assertAction);
 
             //then
-            actualError.Message.Should().Contain(errorCountMessage);
-            actualError.Message.Should().Contain(messageOne);
-            actualError.Message.Should().Contain(messageTwo);
-            actualError.Message.Should().Contain(messageThree);
-            actualError.Message.Should().Contain(messageFour);
+            actualError.Message.Should().BeEquivalentTo(expectedError.ToString());
         }
-
-        //=======================
 
         [Fact(DisplayName = "04.1 - BeEquivalentToShouldPassIfAggregateExceptionsMatch")]
         public void BeEquivalentToShouldPassIfAggregateExceptionsMatch()
@@ -415,8 +410,6 @@ namespace Xeptions.Tests
         {
             // given
             string randomMessage = GetRandomString();
-            Xeption expectedInnerException = new Xeption(message: randomMessage);
-            Exception actualInnerException = new Exception(message: randomMessage);
             string aggregateExpectedMessage = GetRandomString();
             string aggregateActualMessage = GetRandomString();
 
@@ -435,9 +428,113 @@ namespace Xeptions.Tests
                 innerException: actualAggregateException);
 
             string expectedMessage =
-                $"Expected inner exception message to be " +
+                $"Expected aggregate inner exception message to be " +
                 $"\"{expectedAggregateException.Message}\", " +
                 $"but found \"{actualAggregateException.Message}\".";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact(DisplayName = "04.3 - BeEquivalentToShouldFailIfAggregateInnerExceptionsMessagesDontMatch")]
+        public void BeEquivalentToShouldFailIfAggregateInnerExceptionsMessagesDontMatch()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerExceptionOne = new Xeption(message: GetRandomString());
+            Xeption expectedInnerExceptionTwo = new Xeption(message: GetRandomString());
+
+            AggregateException expectedAggregateException = new AggregateException(
+                message: randomMessage,
+                innerExceptions: new List<Exception> { expectedInnerExceptionOne, expectedInnerExceptionTwo });
+
+            AggregateException actualAggregateException = new AggregateException(
+                message: randomMessage);
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedAggregateException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualAggregateException);
+
+            string expectedMessage =
+                $"Expected aggregate inner exception message to be " +
+                $"\"{expectedAggregateException.Message}\", " +
+                $"but found \"{actualAggregateException.Message}\".";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact(DisplayName = "04.3 - BeEquivalentToShouldFailIfAggregateInnerExceptionsDataDontMatch")]
+        public void BeEquivalentToShouldFailIfAggregateInnerExceptionsDataDontMatch()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Xeption actualInnerException = new Xeption(message: randomMessage);
+            string sameKey = GetRandomString();
+            string expectedSameValue = GetRandomString();
+            string unexpectedSameValue = GetRandomString();
+            string expectedKey = $"expected-{GetRandomString()}";
+            string expectedValue = GetRandomString();
+            string unexpectedKey = $"unexpected-{GetRandomString()}";
+            string unexpectedValue = GetRandomString();
+
+            expectedInnerException.AddData(
+                key: expectedKey,
+                values: new[] { expectedValue });
+
+            expectedInnerException.AddData(
+                key: sameKey,
+                values: new[] { expectedSameValue });
+
+            actualInnerException.AddData(
+                key: unexpectedKey,
+                values: new[] { unexpectedValue });
+
+            actualInnerException.AddData(
+                key: sameKey,
+                values: new[] { unexpectedSameValue });
+
+            AggregateException expectedAggregateException = new AggregateException(
+                message: randomMessage,
+                innerExceptions: new List<Exception> { expectedInnerException });
+
+            AggregateException actualAggregateException = new AggregateException(
+                message: randomMessage,
+                innerExceptions: new List<Exception> { actualInnerException });
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedAggregateException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualAggregateException);
+
+            string expectedMessage =
+                $"Expected aggregate inner exception [0] to:{Environment.NewLine}" +
+                $"- contain key '{expectedKey}' with value(s) [{expectedValue}].{Environment.NewLine}" +
+                $"- NOT contain key '{unexpectedKey}'.{Environment.NewLine}" +
+                $"- have key '{sameKey}' with value(s) [{expectedSameValue}], " +
+                $"but found value(s) [{unexpectedSameValue}].";
 
             // when
             Action assertAction = () =>

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -1,4 +1,4 @@
-﻿// ----------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
@@ -546,7 +546,5 @@ namespace Xeptions.Tests
             //then
             actualError.Message.Should().Contain(expectedMessage);
         }
-
-
     }
 }

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -56,9 +56,7 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(expectedMessage);
         }
 
-        // TODO: Remove old tests below at the end of the refactoring
-
-        [Fact]
+        [Fact(DisplayName = "03.1 - BeEquivalentToShouldPassIfExceptionMessagesMatch")]
         public void BeEquivalentToShouldPassIfExceptionMessagesMatch()
         {
             // given
@@ -69,6 +67,8 @@ namespace Xeptions.Tests
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
+
+        // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]
         public void BeEquivalentToShouldPassIfInnerExceptionsMatchOnType()

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -11,6 +11,19 @@ namespace Xeptions.Tests
 {
     public partial class XeptionAssertionTests
     {
+        [Fact(DisplayName = "01.0 - BeEquivalentToShouldPassIfNullExceptionsMatchOnType")]
+        public void BeEquivalentToShouldPassIfNullExceptionsMatchOnType()
+        {
+            // given
+            Xeption expectedException = null;
+            Xeption actualException = null;
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        // TODO: Remove old tests below at the end of the refactoring
+
         [Fact]
         public void BeEquivalentToShouldPassIfExceptionsMatchOnType()
         {
@@ -43,17 +56,6 @@ namespace Xeptions.Tests
 
             //then
             actualError.Message.Should().Contain(expectedMessage);
-        }
-
-        [Fact]
-        public void BeEquivalentToShouldPassIfNullExceptionsMatchOnType()
-        {
-            // given
-            Xeption expectedException = null;
-            Xeption actualException = null;
-
-            // when then
-            actualException.Should().BeEquivalentTo(expectedException);
         }
 
         [Fact]

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -13,8 +13,8 @@ namespace Xeptions.Tests
 {
     public partial class XeptionAssertionTests
     {
-        [Fact(DisplayName = "01.0 - BeEquivalentToShouldPassIfNullExceptionsMatchOnType")]
-        public void BeEquivalentToShouldPassIfNullExceptionsMatchOnType()
+        [Fact(DisplayName = "01.0 - BeEquivalentToShouldPassIfNullExceptionsMatch")]
+        public void BeEquivalentToShouldPassIfNullExceptionsMatch()
         {
             // given
             Xeption expectedException = null;
@@ -24,8 +24,8 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        [Fact(DisplayName = "02.1 - BeEquivalentToShouldPassIfExceptionsMatchOnType")]
-        public void BeEquivalentToShouldPassIfExceptionsMatchOnType()
+        [Fact(DisplayName = "02.1 - BeEquivalentToShouldPassIfExceptionsMatch")]
+        public void BeEquivalentToShouldPassIfExceptionsMatch()
         {
             // given
             string randomMessage = GetRandomString();
@@ -59,19 +59,7 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(expectedMessage);
         }
 
-        [Fact(DisplayName = "03.1 - BeEquivalentToShouldPassIfExceptionMessagesMatch")]
-        public void BeEquivalentToShouldPassIfExceptionMessagesMatch()
-        {
-            // given
-            string randomMessage = GetRandomString();
-            var expectedException = new Xeption(message: randomMessage);
-            var actualException = new Xeption(message: randomMessage);
-
-            // when then
-            actualException.Should().BeEquivalentTo(expectedException);
-        }
-
-        [Fact(DisplayName = "03.2 - BeEquivalentToShouldFailIfExceptionMessagesDontMatch")]
+        [Fact(DisplayName = "02.3 - BeEquivalentToShouldFailIfExceptionMessagesDontMatch")]
         public void BeEquivalentToShouldFailIfExceptionMessagesDontMatch()
         {
             // given
@@ -93,7 +81,7 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(expectedMessage);
         }
 
-        [Fact(DisplayName = "04.1 - BeEquivalentToShouldPassIfExceptionDataMatch")]
+        [Fact(DisplayName = "02.4 - BeEquivalentToShouldPassIfExceptionDataMatch")]
         public void BeEquivalentToShouldPassIfExceptionDataMatch()
         {
             // given
@@ -120,7 +108,7 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        [Fact(DisplayName = "04.2 - BeEquivalentToShouldFailIfExceptionDataDontMatch")]
+        [Fact(DisplayName = "02.5 - BeEquivalentToShouldFailIfExceptionDataDontMatch")]
         public void BeEquivalentToShouldFailIfExceptionDataDontMatch()
         {
             // given
@@ -193,7 +181,7 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(messageFour);
         }
 
-        [Fact(DisplayName = "05.1 - BeEquivalentToShouldPassIfInnerExceptionsMatchOnType")]
+        [Fact(DisplayName = "03.1 - BeEquivalentToShouldPassIfInnerExceptionsMatch")]
         public void BeEquivalentToShouldPassIfInnerExceptionsMatchOnType()
         {
             // given
@@ -213,7 +201,7 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        [Fact(DisplayName = "05.2 - BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType")]
+        [Fact(DisplayName = "03.2 - BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType")]
         public void BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType()
         {
             // given
@@ -232,6 +220,37 @@ namespace Xeptions.Tests
             string expectedMessage =
                 $"Expected exception type to be \"{expectedInnerException.GetType().FullName}\", " +
                 $"but found \"{actualInnerException.GetType().FullName}\".";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact(DisplayName = "03.3 - BeEquivalentToShouldFailIfInnerExceptionMessagesDontMatch")]
+        public void BeEquivalentToShouldFailIfInnerExceptionMessagesDontMatch()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedInnerException = new Xeption(message: GetRandomString());
+            var actualInnerException = new Xeption(message: GetRandomString());
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            string expectedMessage =
+                $"Expected exception message to be \"{expectedInnerException.Message}\", " +
+                $"but found \"{actualInnerException.Message}\"";
 
             // when
             Action assertAction = () =>

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -151,7 +151,7 @@ namespace Xeptions.Tests
                 key: actualData.Key,
                 values: actualData.Value.ToArray());
 
-            StringBuilder expectedError = new StringBuilder();
+            var expectedError = new StringBuilder();
             expectedError.AppendLine($"Expected exception to:");
 
             expectedError.AppendLine(
@@ -337,7 +337,7 @@ namespace Xeptions.Tests
                 key: actualData.Key,
                 values: actualData.Value.ToArray());
 
-            StringBuilder expectedError = new StringBuilder();
+            var expectedError = new StringBuilder();
             expectedError.AppendLine($"Expected inner exception to:");
 
             expectedError.AppendLine(

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -263,6 +263,42 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(expectedMessage);
         }
 
+        [Fact(DisplayName = "02.4 - BeEquivalentToShouldPassIfInnerExceptionDataMatch")]
+        public void BeEquivalentToShouldPassIfInnerExceptionDataMatch()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            KeyValuePair<string, List<string>> randomData = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> expectedData = randomData.DeepClone();
+            KeyValuePair<string, List<string>> actualData = randomData.DeepClone();
+
+            var expectedInnerException = new Xeption(
+                message: exceptionMessage);
+
+            expectedInnerException.AddData(
+                key: expectedData.Key,
+                values: expectedData.Value.ToArray());
+
+            var actualInnerException = new Xeption(
+                message: exceptionMessage);
+
+            actualInnerException.AddData(
+                key: actualData.Key,
+                values: actualData.Value.ToArray());
+
+
+            var expectedException = new Xeption(
+                message: exceptionMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: exceptionMessage,
+                innerException: actualInnerException);
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+
         // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -22,9 +22,7 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        // TODO: Remove old tests below at the end of the refactoring
-
-        [Fact]
+        [Fact(DisplayName = "02.1 - BeEquivalentToShouldPassIfExceptionsMatchOnType")]
         public void BeEquivalentToShouldPassIfExceptionsMatchOnType()
         {
             // given
@@ -35,6 +33,8 @@ namespace Xeptions.Tests
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
+
+        // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]
         public void BeEquivalentToShouldFailIfExceptionsDontMatchOnType()

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -34,9 +34,7 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        // TODO: Remove old tests below at the end of the refactoring
-
-        [Fact]
+        [Fact(DisplayName = "02.2 - BeEquivalentToShouldFailIfExceptionsDontMatchOnType")]
         public void BeEquivalentToShouldFailIfExceptionsDontMatchOnType()
         {
             // given
@@ -57,6 +55,8 @@ namespace Xeptions.Tests
             //then
             actualError.Message.Should().Contain(expectedMessage);
         }
+
+        // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]
         public void BeEquivalentToShouldPassIfExceptionMessagesMatch()

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -2,8 +2,10 @@
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
+using System;
 using FluentAssertions;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Xeptions.Tests
 {
@@ -19,6 +21,28 @@ namespace Xeptions.Tests
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        [Fact]
+        public void BeEquivalentToShouldFailIfExceptionsDontMatchOnType()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedException = new Xeption(message: randomMessage);
+            var actualException = new Exception(message: randomMessage);
+
+            string expectedMessage =
+                "Expected exception type to be \"Xeptions.Xeption\", but found \"System.Exception\".";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
         }
 
         [Fact]

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -119,6 +119,79 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
+        [Fact(DisplayName = "04.2 - BeEquivalentToShouldFailIfExceptionDataDontMatch")]
+        public void BeEquivalentToShouldFailIfExceptionDataDontMatch()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string mutualKey = GetRandomString();
+            KeyValuePair<string, List<string>> expectedDataOne = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> expectedDataTwo = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> actualData = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> expectedDataSameKeyName = GenerateKeyValuePair(count: 1, mutualKey);
+            KeyValuePair<string, List<string>> actualDataSameKeyName = GenerateKeyValuePair(count: 1, mutualKey);
+
+            var expectedException = new Xeption(
+                message: exceptionMessage);
+
+            expectedException.AddData(
+                key: expectedDataTwo.Key,
+                values: expectedDataTwo.Value.ToArray());
+
+            expectedException.AddData(
+                key: expectedDataOne.Key,
+                values: expectedDataOne.Value.ToArray());
+
+            expectedException.AddData(
+                key: expectedDataSameKeyName.Key,
+                values: expectedDataSameKeyName.Value.ToArray());
+
+            var actualException = new Xeption(
+                message: exceptionMessage);
+
+            actualException.AddData(
+                key: actualData.Key,
+                values: actualData.Value.ToArray());
+
+            actualException.AddData(
+                key: actualDataSameKeyName.Key,
+                values: actualDataSameKeyName.Value.ToArray());
+
+            string titleMessage =
+                $"Expected exception with type '{expectedException.GetType().FullName}' " +
+                $"and message '{expectedException.Message}' to:";
+
+            string errorCountMessage =
+                $"- have an expected data item count to be {expectedException.Data.Count}, " +
+                $"but found {actualException.Data.Count}.";
+
+            string messageOne =
+                $"- contain key '{expectedDataOne.Key}', but it was not found.";
+
+            string messageTwo =
+                $"- contain key '{expectedDataTwo.Key}', but it was not found.";
+
+            string messageThree =
+                $"- not contain key '{actualData.Key}'.";
+
+            string messageFour =
+                $"- not contain key '{actualData.Key}'.";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(errorCountMessage);
+            actualError.Message.Should().Contain(messageOne);
+            actualError.Message.Should().Contain(messageTwo);
+            actualError.Message.Should().Contain(messageThree);
+            actualError.Message.Should().Contain(messageFour);
+        }
+
         // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -192,9 +192,7 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(messageFour);
         }
 
-        // TODO: Remove old tests below at the end of the refactoring
-
-        [Fact]
+        [Fact(DisplayName = "05.1 - BeEquivalentToShouldPassIfInnerExceptionsMatchOnType")]
         public void BeEquivalentToShouldPassIfInnerExceptionsMatchOnType()
         {
             // given
@@ -213,6 +211,8 @@ namespace Xeptions.Tests
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
+
+        // TODO: Remove old tests below at the end of the refactoring
 
         [Fact]
         public void BeEquivalentToShouldPassIfInnerExceptionMessagesMatch()

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -3,7 +3,9 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
+using Force.DeepCloner;
 using Xunit;
 using Xunit.Sdk;
 
@@ -88,6 +90,33 @@ namespace Xeptions.Tests
 
             //then
             actualError.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact(DisplayName = "04.1 - BeEquivalentToShouldPassIfExceptionDataMatch")]
+        public void BeEquivalentToShouldPassIfExceptionDataMatch()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            KeyValuePair<string, List<string>> randomData = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> expectedData = randomData.DeepClone();
+            KeyValuePair<string, List<string>> actualData = randomData.DeepClone();
+
+            var expectedException = new Xeption(
+                message: exceptionMessage);
+
+            expectedException.AddData(
+                key: expectedData.Key,
+                values: expectedData.Value.ToArray());
+
+            var actualException = new Xeption(
+                message: exceptionMessage);
+
+            actualException.AddData(
+                key: actualData.Key,
+                values: actualData.Value.ToArray());
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
         }
 
         // TODO: Remove old tests below at the end of the refactoring

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -201,8 +201,8 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        [Fact(DisplayName = "03.2 - BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType")]
-        public void BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType()
+        [Fact(DisplayName = "03.2 - BeEquivalentToShouldFailIfInnerExceptionsTypeDontMatch")]
+        public void BeEquivalentToShouldFailIfInnerExceptionsTypeDontMatch()
         {
             // given
             string randomMessage = GetRandomString();
@@ -218,7 +218,7 @@ namespace Xeptions.Tests
                 innerException: actualInnerException);
 
             string expectedMessage =
-                $"Expected exception type to be \"{expectedInnerException.GetType().FullName}\", " +
+                $"Expected inner exception type to be \"{expectedInnerException.GetType().FullName}\", " +
                 $"but found \"{actualInnerException.GetType().FullName}\".";
 
             // when
@@ -232,8 +232,8 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(expectedMessage);
         }
 
-        [Fact(DisplayName = "03.3 - BeEquivalentToShouldFailIfInnerExceptionMessagesDontMatch")]
-        public void BeEquivalentToShouldFailIfInnerExceptionMessagesDontMatch()
+        [Fact(DisplayName = "03.3 - BeEquivalentToShouldFailIfInnerExceptionMessageDontMatch")]
+        public void BeEquivalentToShouldFailIfInnerExceptionMessageDontMatch()
         {
             // given
             string randomMessage = GetRandomString();
@@ -249,7 +249,7 @@ namespace Xeptions.Tests
                 innerException: actualInnerException);
 
             string expectedMessage =
-                $"Expected exception message to be \"{expectedInnerException.Message}\", " +
+                $"Expected inner exception message to be \"{expectedInnerException.Message}\", " +
                 $"but found \"{actualInnerException.Message}\"";
 
             // when
@@ -263,7 +263,7 @@ namespace Xeptions.Tests
             actualError.Message.Should().Contain(expectedMessage);
         }
 
-        [Fact(DisplayName = "02.4 - BeEquivalentToShouldPassIfInnerExceptionDataMatch")]
+        [Fact(DisplayName = "03.4 - BeEquivalentToShouldPassIfInnerExceptionDataMatch")]
         public void BeEquivalentToShouldPassIfInnerExceptionDataMatch()
         {
             // given
@@ -286,7 +286,6 @@ namespace Xeptions.Tests
                 key: actualData.Key,
                 values: actualData.Value.ToArray());
 
-
             var expectedException = new Xeption(
                 message: exceptionMessage,
                 innerException: expectedInnerException);
@@ -299,72 +298,158 @@ namespace Xeptions.Tests
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        // TODO: Remove old tests below at the end of the refactoring
+        [Fact(DisplayName = "03.5 - BeEquivalentToShouldFailIfInnerExceptionDataDontMatch")]
+        public void BeEquivalentToShouldFailIfAggregateInnerExceptionDataDontMatch()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string mutualKey = GetRandomString();
+            KeyValuePair<string, List<string>> expectedDataOne = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> expectedDataTwo = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> actualData = GenerateKeyValuePair(count: 1);
+            KeyValuePair<string, List<string>> expectedDataSameKeyName = GenerateKeyValuePair(count: 1, mutualKey);
+            KeyValuePair<string, List<string>> actualDataSameKeyName = GenerateKeyValuePair(count: 1, mutualKey);
 
-        [Fact]
-        public void BeEquivalentToShouldPassIfInnerExceptionMessagesMatch()
+            var expectedInnerException = new Xeption(
+                message: exceptionMessage);
+
+            expectedInnerException.AddData(
+                key: expectedDataTwo.Key,
+                values: expectedDataTwo.Value.ToArray());
+
+            expectedInnerException.AddData(
+                key: expectedDataOne.Key,
+                values: expectedDataOne.Value.ToArray());
+
+            expectedInnerException.AddData(
+                key: expectedDataSameKeyName.Key,
+                values: expectedDataSameKeyName.Value.ToArray());
+
+            var actualInnerException = new Xeption(
+                message: exceptionMessage);
+
+            actualInnerException.AddData(
+                key: actualData.Key,
+                values: actualData.Value.ToArray());
+
+            actualInnerException.AddData(
+                key: actualDataSameKeyName.Key,
+                values: actualDataSameKeyName.Value.ToArray());
+
+            string titleMessage =
+                $"Expected exception with type '{expectedInnerException.GetType().FullName}' " +
+                $"and message '{expectedInnerException.Message}' to:";
+
+            string errorCountMessage =
+                $"- have an expected data item count to be {expectedInnerException.Data.Count}, " +
+                $"but found {actualInnerException.Data.Count}.";
+
+            string messageOne =
+                $"- contain key '{expectedDataOne.Key}', but it was not found.";
+
+            string messageTwo =
+                $"- contain key '{expectedDataTwo.Key}', but it was not found.";
+
+            string messageThree =
+                $"- not contain key '{actualData.Key}'.";
+
+            string messageFour =
+                $"- not contain key '{actualData.Key}'.";
+
+            var expectedException = new Xeption(
+                message: exceptionMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: exceptionMessage,
+                innerException: actualInnerException);
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(errorCountMessage);
+            actualError.Message.Should().Contain(messageOne);
+            actualError.Message.Should().Contain(messageTwo);
+            actualError.Message.Should().Contain(messageThree);
+            actualError.Message.Should().Contain(messageFour);
+        }
+
+        //=======================
+
+        [Fact(DisplayName = "04.1 - BeEquivalentToShouldPassIfAggregateExceptionsMatch")]
+        public void BeEquivalentToShouldPassIfAggregateExceptionsMatch()
         {
             // given
             string randomMessage = GetRandomString();
-            var expectedException = new Xeption(message: randomMessage);
-            var actualException = new Xeption(message: randomMessage);
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Xeption actualInnerException = new Xeption(message: randomMessage);
+            string aggregateExceptionMessage = GetRandomString();
 
-            // when then
-            actualException.Should().BeEquivalentTo(expectedException);
-        }
+            AggregateException expectedAggregateException = new AggregateException(
+                message: aggregateExceptionMessage,
+                innerExceptions: new List<Exception> { expectedInnerException });
 
-        [Fact]
-        public void ShouldPassIfInnerExceptionDataCountMatch()
-        {
-            // given
-            string exceptionMessage = GetRandomString();
-            var expectedInnerException = new Xeption(message: exceptionMessage);
-            var actualInnerException = new Xeption(message: exceptionMessage);
+            AggregateException actualAggregateException = new AggregateException(
+                message: aggregateExceptionMessage,
+                innerExceptions: new List<Exception> { actualInnerException });
 
             var expectedException = new Xeption(
-                message: exceptionMessage,
-                innerException: expectedInnerException);
+                message: randomMessage,
+                innerException: expectedAggregateException);
 
             var actualException = new Xeption(
-                message: exceptionMessage,
-                innerException: actualInnerException);
+                message: randomMessage,
+                innerException: actualAggregateException);
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
 
-        [Fact]
-        public void ShouldPassIfInnerExceptionDataMatch()
+        [Fact(DisplayName = "04.2 - BeEquivalentToShouldFailIfAggregateExceptionsDontMatchOnMessage")]
+        public void BeEquivalentToShouldFailIfAggregateExceptionsDontMatchOnMessage()
         {
             // given
-            string exceptionMessage = GetRandomString();
-            string randomKey = GetRandomString();
-            string randomValue = GetRandomString();
-            string expectedInnerExceptionDataKey = randomKey;
-            string expectedInnerExceptionDataValue = randomValue;
-            string actualInnerExceptionDataKey = randomKey;
-            string actualInnerExceptionDataValue = randomValue;
-            var expectedInnerException = new Xeption(message: exceptionMessage);
-            var actualInnerException = new Xeption(message: exceptionMessage);
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Exception actualInnerException = new Exception(message: randomMessage);
+            string aggregateExpectedMessage = GetRandomString();
+            string aggregateActualMessage = GetRandomString();
 
-            expectedInnerException.AddData(
-                key: expectedInnerExceptionDataKey,
-                values: expectedInnerExceptionDataValue);
+            AggregateException expectedAggregateException = new AggregateException(
+                message: aggregateExpectedMessage);
 
-            actualInnerException.AddData(
-                key: actualInnerExceptionDataKey,
-                values: actualInnerExceptionDataValue);
+            AggregateException actualAggregateException = new AggregateException(
+                message: aggregateActualMessage);
 
             var expectedException = new Xeption(
-                message: exceptionMessage,
-                innerException: expectedInnerException);
+                message: randomMessage,
+                innerException: expectedAggregateException);
 
             var actualException = new Xeption(
-                message: exceptionMessage,
-                innerException: actualInnerException);
+                message: randomMessage,
+                innerException: actualAggregateException);
 
-            // when then
-            actualException.Should().BeEquivalentTo(expectedException);
+            string expectedMessage =
+                $"Expected inner exception message to be " +
+                $"\"{expectedAggregateException.Message}\", " +
+                $"but found \"{actualAggregateException.Message}\".";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
         }
+
+
     }
 }

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -45,7 +45,8 @@ namespace Xeptions.Tests
             var actualException = new Exception(message: randomMessage);
 
             string expectedMessage =
-                "Expected exception type to be \"Xeptions.Xeption\", but found \"System.Exception\".";
+                $"Expected exception type to be \"{expectedException.GetType().FullName}\", " +
+                $"but found \"{actualException.GetType().FullName}\".";
 
             // when
             Action assertAction = () =>
@@ -210,6 +211,37 @@ namespace Xeptions.Tests
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        [Fact(DisplayName = "05.2 - BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType")]
+        public void BeEquivalentToShouldFailIfInnerExceptionsDontMatchOnType()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Exception actualInnerException = new Exception(message: randomMessage);
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            string expectedMessage =
+                $"Expected exception type to be \"{expectedInnerException.GetType().FullName}\", " +
+                $"but found \"{actualInnerException.GetType().FullName}\".";
+
+            // when
+            Action assertAction = () =>
+                actualException.Should().BeEquivalentTo(expectedException);
+
+            XunitException actualError =
+                Assert.Throws<XunitException>(assertAction);
+
+            //then
+            actualError.Message.Should().Contain(expectedMessage);
         }
 
         // TODO: Remove old tests below at the end of the refactoring

--- a/Xeption.Tests/XeptionAssertionTests.cs
+++ b/Xeption.Tests/XeptionAssertionTests.cs
@@ -19,7 +19,7 @@ namespace Xeptions.Tests
 
         private static KeyValuePair<string, List<string>> GenerateKeyValuePair(int count, string keyName = "")
         {
-            if (string.IsNullOrWhiteSpace(keyName))
+            if (String.IsNullOrWhiteSpace(keyName))
             {
                 keyName = GetRandomString();
             }

--- a/Xeption.Tests/XeptionAssertionTests.cs
+++ b/Xeption.Tests/XeptionAssertionTests.cs
@@ -29,7 +29,7 @@ namespace Xeptions.Tests
                 .ToList();
 
             var keyValuePair = new KeyValuePair<string, List<string>>(
-                key: GetRandomString(),
+                key: keyName,
                 value: values);
 
             return keyValuePair;

--- a/Xeption.Tests/XeptionAssertionTests.cs
+++ b/Xeption.Tests/XeptionAssertionTests.cs
@@ -24,7 +24,7 @@ namespace Xeptions.Tests
                 keyName = GetRandomString();
             }
 
-            List<string> values = Enumerable.Range(start: 0, count: count)
+            List<string> values = Enumerable.Range(start: 0, count)
                 .Select(_ => GetRandomString())
                 .ToList();
 

--- a/Xeption.Tests/XeptionAssertionTests.cs
+++ b/Xeption.Tests/XeptionAssertionTests.cs
@@ -3,14 +3,37 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Tynamix.ObjectFiller;
 
 namespace Xeptions.Tests
 {
     public partial class XeptionAssertionTests
     {
+        private static int GetRandomNumber() =>
+            new IntRange(min: 2, max: 10).GetValue();
+
         private static string GetRandomString() =>
             new MnemonicString().GetValue();
+
+        private static KeyValuePair<string, List<string>> GenerateKeyValuePair(int count, string keyName = "")
+        {
+            if (string.IsNullOrWhiteSpace(keyName))
+            {
+                keyName = GetRandomString();
+            }
+
+            List<string> values = Enumerable.Range(start: 0, count: count)
+                .Select(_ => GetRandomString())
+                .ToList();
+
+            var keyValuePair = new KeyValuePair<string, List<string>>(
+                key: GetRandomString(),
+                value: values);
+
+            return keyValuePair;
+        }
 
         internal class OtherTarget
         {

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -121,6 +121,34 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfExceptionsDontMatchOnTypeWithErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedInnerException = new Xeption(message: randomMessage);
+
+            expectedInnerException.AddData(
+                key: GetRandomString(),
+                values: GetRandomString());
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Exception(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfInnerExceptionsDontMatchOnType()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -459,6 +459,35 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfExceptionMessageDontMatchWithErrorDetails()
+        {
+            // given
+            string randomExceptionMessage = GetRandomString();
+            string innerExceptionMessage = randomExceptionMessage;
+            string expectedExceptionMessage = GetRandomString();
+            string actualExceptionMessage = GetRandomString();
+
+            var innerException = new Xeption(
+                message: innerExceptionMessage);
+
+            var expectedException = new Xeption(
+                message: expectedExceptionMessage,
+                innerException: innerException);
+
+            var actualException = new Xeption(
+                message: actualExceptionMessage,
+                innerException: innerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfInnerExceptionMessageDontMatch()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -578,6 +578,44 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfInnerExceptionDataDontMatchWithErrorDetails()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string expectedInnerExceptionDataKey = GetRandomString();
+            string expectedInnerExceptionDataValue = GetRandomString();
+            string actualInnerExceptionDataKey = GetRandomString();
+            string actualInnerExceptionDataValue = GetRandomString();
+
+            var expectedInnerException = new Xeption(message: exceptionMessage);
+            var actualInnerException = new Xeption(message: exceptionMessage);
+
+            expectedInnerException.AddData(
+                key: expectedInnerExceptionDataKey,
+                values: expectedInnerExceptionDataValue);
+
+            actualInnerException.AddData(
+                key: actualInnerExceptionDataKey,
+                values: actualInnerExceptionDataValue);
+
+            var expectedException = new Xeption(
+                message: exceptionMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: exceptionMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfExceptionDataDontMatch()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -222,6 +222,31 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfActualInnerExceptionIsNullWhileExpectedInnerExceptionIsPresentWithErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Exception actualInnerException = null;
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfExpectedExceptionIsNullWhileActualExceptionIsPresent()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -268,6 +268,28 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfExpectedExceptionIsNullWhileActualExceptionIsPresentWithErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Exception actualInnerException = new Exception(message: randomMessage);
+
+            Xeption expectedException = null;
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfActualExceptionIsNullWhileExpectedExceptionIsPresent()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -78,6 +78,22 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnTrueIfBothExceptionsMatchOnNullWithEmptyErrorDetails()
+        {
+            // given
+            Xeption expectedException = null;
+            Xeption actualException = null;
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.True(actualComparisonResult);
+            message.Should().BeEmpty();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfExceptionsDontMatchOnType()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -311,6 +311,28 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfActualExceptionIsNullWhileExpectedExceptionIsPresentWithErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = null;
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            Xeption actualException = null;
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfExpectedInnerExceptionIsNullWhileActualInnerExceptionIsPresent()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -406,6 +406,31 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnTrueIfOuterExceptionsMatchWithNullInnerExceptionsWithNoErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = null;
+            Xeption actualInnerException = null;
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.True(actualComparisonResult);
+            message.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfExceptionMessageDontMatch()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using FluentAssertions;
 using Force.DeepCloner;
 using Xunit;
 
@@ -33,6 +34,32 @@ namespace Xeptions.Tests
 
             // then
             Assert.True(actualComparisonResult);
+        }
+
+        [Fact]
+        public void ShouldReturnTrueIfExceptionsMatchWithEmptyErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedInnerException = new Xeption(message: randomMessage);
+
+            expectedInnerException.AddData(
+                key: GetRandomString(),
+                values: GetRandomString());
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = expectedException.DeepClone();
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.True(actualComparisonResult);
+            message.Should().BeEmpty();
         }
 
         [Fact]

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -514,6 +514,33 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfInnerExceptionMessageDontMatchWithErrorDetails()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string expectedInnerExceptionMessage = GetRandomString();
+            string actualInnerExceptionMessage = GetRandomString();
+            var expectedInnerException = new Xeption(message: expectedInnerExceptionMessage);
+            var actualInnerException = new Xeption(message: actualInnerExceptionMessage);
+
+            var expectedException = new Xeption(
+                message: exceptionMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: exceptionMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfInnerExceptionDataDontMatch()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -357,6 +357,31 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfExpectedInnerExceptionIsNullWhileActualInnerExceptionIsPresentWithErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = null;
+            Exception actualInnerException = new Exception(message: randomMessage);
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnTrueIfOuterExceptionsMatchWithNullInnerExceptions()
         {
             // given

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -643,5 +643,35 @@ namespace Xeptions.Tests
             // then
             Assert.False(actualComparisonResult);
         }
+
+        [Fact]
+        public void ShouldReturnFalseIfExceptionDataDontMatchWithErrorDetails()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string expectedExceptionDataKey = GetRandomString();
+            string expectedExceptionDataValue = GetRandomString();
+            string actualExceptionDataKey = GetRandomString();
+            string actualExceptionDataValue = GetRandomString();
+
+            var expectedException = new Xeption(message: exceptionMessage);
+            var actualException = new Xeption(message: exceptionMessage);
+
+            expectedException.AddData(
+                key: expectedExceptionDataKey,
+                values: expectedExceptionDataValue);
+
+            actualException.AddData(
+                key: actualExceptionDataKey,
+                values: actualExceptionDataValue);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
     }
 }

--- a/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.SameExceptionAs.cs
@@ -173,6 +173,31 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldReturnFalseIfInnerExceptionsDontMatchOnTypeWithErrorDetails()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Exception actualInnerException = new Exception(message: randomMessage);
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
+
+            // when
+            bool actualComparisonResult =
+                expectedException.SameExceptionAs(actualException, out string message);
+
+            // then
+            Assert.False(actualComparisonResult);
+            message.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
         public void ShouldReturnFalseIfActualInnerExceptionIsNullWhileExpectedInnerExceptionIsPresent()
         {
             // given

--- a/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
+++ b/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
@@ -82,6 +82,16 @@ namespace Xeptions.Tests
             Xeption actualXeption = expectedXeption.DeepClone();
             expectedXeption.UpsertDataList(randomKey, randomValue);
 
+            StringBuilder expectedMessage = new StringBuilder();
+            expectedMessage.AppendLine($"Expected data to: ");
+
+            expectedMessage.AppendLine(
+                $"- have a count of {expectedXeption.Data.Count}, " +
+                $"but found {actualXeption.Data.Count}.");
+
+            expectedMessage.AppendLine(
+                $"- contain key '{randomKey}' with value(s) [{randomValue}].");
+
             // when
             var actualComparisonResult = actualXeption
                 .DataEqualsWithDetail(expectedXeption.Data);
@@ -89,13 +99,7 @@ namespace Xeptions.Tests
             // then
             actualComparisonResult.IsEqual.Should().BeFalse();
             actualComparisonResult.Message.Should().NotBeNullOrEmpty();
-
-            actualComparisonResult.Message.Should()
-                .Contain($"- Expected data item count to be {expectedXeption.Data.Count}, " +
-                    $"but found {actualXeption.Data.Count}.");
-
-            actualComparisonResult.Message.Should()
-                .Contain($"- Expected to find key '{randomKey}'.");
+            actualComparisonResult.Message.Should().BeEquivalentTo(expectedMessage.ToString());
         }
 
         [Fact]

--- a/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
+++ b/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
@@ -25,11 +25,11 @@ namespace Xeptions.Tests
             Xeption actualXeption = expectedXeption.DeepClone();
 
             // when
-            var actualComparisonResult = actualXeption.DataEqualsWithDetail(expectedXeption.Data);
+            (bool isEqual, string message) = actualXeption.DataEqualsWithDetail(expectedXeption.Data);
 
             // then
-            actualComparisonResult.IsEqual.Should().BeTrue();
-            actualComparisonResult.Message.Should().BeNullOrEmpty();
+            isEqual.Should().BeTrue();
+            message.Should().BeNullOrEmpty();
         }
 
         [Fact]
@@ -58,12 +58,12 @@ namespace Xeptions.Tests
             expectedMessage.AppendLine($"- NOT contain key '{randomKey}'.");
 
             // when
-            var actualComparisonResult = actualXeption.DataEqualsWithDetail(expectedXeption.Data);
+            (bool isEqual, string message) = actualXeption.DataEqualsWithDetail(expectedXeption.Data);
 
             // then
-            actualComparisonResult.IsEqual.Should().BeFalse();
-            actualComparisonResult.Message.Should().NotBeNullOrEmpty();
-            actualComparisonResult.Message.Should().BeEquivalentTo(expectedMessage.ToString());
+            isEqual.Should().BeFalse();
+            message.Should().NotBeNullOrEmpty();
+            message.Should().BeEquivalentTo(expectedMessage.ToString());
         }
 
         [Fact]
@@ -93,13 +93,13 @@ namespace Xeptions.Tests
                 $"- contain key '{randomKey}' with value(s) [{randomValue}].");
 
             // when
-            var actualComparisonResult = actualXeption
+            (bool isEqual, string message) = actualXeption
                 .DataEqualsWithDetail(expectedXeption.Data);
 
             // then
-            actualComparisonResult.IsEqual.Should().BeFalse();
-            actualComparisonResult.Message.Should().NotBeNullOrEmpty();
-            actualComparisonResult.Message.Should().BeEquivalentTo(expectedMessage.ToString());
+            isEqual.Should().BeFalse();
+            message.Should().NotBeNullOrEmpty();
+            message.Should().BeEquivalentTo(expectedMessage.ToString());
         }
 
         [Fact]
@@ -134,13 +134,13 @@ namespace Xeptions.Tests
                 $"but found value(s) ['{actualValues}'].");
 
             // when
-            var actualComparisonResult = actualXeption
+            (bool isEqual, string message) = actualXeption
                 .DataEqualsWithDetail(expectedXeption.Data);
 
             // then
-            actualComparisonResult.IsEqual.Should().BeFalse();
-            actualComparisonResult.Message.Should().NotBeNullOrEmpty();
-            actualComparisonResult.Message.Should().BeEquivalentTo(expectedMessage.ToString());
+            isEqual.Should().BeFalse();
+            message.Should().NotBeNullOrEmpty();
+            message.Should().BeEquivalentTo(expectedMessage.ToString());
         }
     }
 }

--- a/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
+++ b/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
@@ -126,6 +126,13 @@ namespace Xeptions.Tests
             string actualValues = ((List<string>)actualXeption.Data[randomKey])
                 .Select(value => value).Aggregate((t1, t2) => t1 + "','" + t2);
 
+            StringBuilder expectedMessage = new StringBuilder();
+            expectedMessage.AppendLine($"Expected data to: ");
+
+            expectedMessage.AppendLine(
+                $"- have key '{randomKey}' with value(s) ['{expectedValues}'], " +
+                $"but found value(s) ['{actualValues}'].");
+
             // when
             var actualComparisonResult = actualXeption
                 .DataEqualsWithDetail(expectedXeption.Data);
@@ -133,10 +140,7 @@ namespace Xeptions.Tests
             // then
             actualComparisonResult.IsEqual.Should().BeFalse();
             actualComparisonResult.Message.Should().NotBeNullOrEmpty();
-
-            actualComparisonResult.Message.Should()
-                .Contain($"- Expected to find key '{randomKey}' with value(s) ['{expectedValues}'], " +
-                    $"but found value(s) ['{actualValues}'].");
+            actualComparisonResult.Message.Should().BeEquivalentTo(expectedMessage.ToString());
         }
     }
 }

--- a/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
+++ b/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
@@ -48,7 +48,7 @@ namespace Xeptions.Tests
             Xeption actualXeption = expectedXeption.DeepClone();
             actualXeption.UpsertDataList(randomKey, randomValue);
 
-            StringBuilder expectedMessage = new StringBuilder();
+            var expectedMessage = new StringBuilder();
             expectedMessage.AppendLine($"Expected data to: ");
 
             expectedMessage.AppendLine(
@@ -82,7 +82,7 @@ namespace Xeptions.Tests
             Xeption actualXeption = expectedXeption.DeepClone();
             expectedXeption.UpsertDataList(randomKey, randomValue);
 
-            StringBuilder expectedMessage = new StringBuilder();
+            var expectedMessage = new StringBuilder();
             expectedMessage.AppendLine($"Expected data to: ");
 
             expectedMessage.AppendLine(
@@ -126,7 +126,7 @@ namespace Xeptions.Tests
             string actualValues = ((List<string>)actualXeption.Data[randomKey])
                 .Select(value => value).Aggregate((t1, t2) => t1 + "','" + t2);
 
-            StringBuilder expectedMessage = new StringBuilder();
+            var expectedMessage = new StringBuilder();
             expectedMessage.AppendLine($"Expected data to: ");
 
             expectedMessage.AppendLine(

--- a/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
+++ b/Xeption.Tests/XeptionTests.Logic.DataEqualsWithMessage.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using FluentAssertions;
 using Force.DeepCloner;
 using Xunit;
@@ -47,19 +48,22 @@ namespace Xeptions.Tests
             Xeption actualXeption = expectedXeption.DeepClone();
             actualXeption.UpsertDataList(randomKey, randomValue);
 
+            StringBuilder expectedMessage = new StringBuilder();
+            expectedMessage.AppendLine($"Expected data to: ");
+
+            expectedMessage.AppendLine(
+                $"- have a count of {expectedXeption.Data.Count}, " +
+                $"but found {actualXeption.Data.Count}.");
+
+            expectedMessage.AppendLine($"- NOT contain key '{randomKey}'.");
+
             // when
             var actualComparisonResult = actualXeption.DataEqualsWithDetail(expectedXeption.Data);
 
             // then
             actualComparisonResult.IsEqual.Should().BeFalse();
             actualComparisonResult.Message.Should().NotBeNullOrEmpty();
-
-            actualComparisonResult.Message.Should()
-                .Contain($"- Expected data item count to be {expectedXeption.Data.Count}, " +
-                    $"but found {actualXeption.Data.Count}.");
-
-            actualComparisonResult.Message.Should()
-                .Contain($"- Did not expect to find key '{randomKey}'.");
+            actualComparisonResult.Message.Should().BeEquivalentTo(expectedMessage.ToString());
         }
 
         [Fact]

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -3,6 +3,9 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Xeptions;
@@ -13,8 +16,7 @@ namespace FluentAssertions.Exceptions
     where TException : Exception
     {
         public XeptionAssertions(TException exception) : base(exception)
-        {
-        }
+        { }
 
         public AndConstraint<XeptionAssertions<TException>> BeEquivalentTo(
             Exception expectation,
@@ -25,65 +27,188 @@ namespace FluentAssertions.Exceptions
                 ? new Xeption()
                 : new Xeption(Subject.Message, Subject.InnerException, Subject.Data);
 
-            var expectedException = expectation ?? new Exception();
-            var actualInnerException = Subject?.InnerException as Xeption ?? new Xeption();
-            var expectedInnerException = expectation?.InnerException ?? new Exception();
-            var exceptionDataComparisonResult = actualException.DataEqualsWithDetail(expectedException.Data);
-
-            var innerExceptionDataComparisonResult =
-                actualInnerException.DataEqualsWithDetail(expectedInnerException.Data);
-
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the ")
                 .Given(() => Subject)
-                .ForCondition(subject => subject?.GetType()?.FullName == expectation?.GetType()?.FullName)
-                .FailWith(
-                    "type to be {0}, but found the type to be {1}.",
-                    expectation?.GetType()?.FullName,
-                    Subject?.GetType()?.FullName)
-                .Then
-                .ForCondition(subject => subject?.Message == expectation?.Message)
-                .FailWith(
-                    "message to be {0}, but found {1}.",
-                    expectation?.Message,
-                    Subject?.Message)
-                .Then
-                .ForCondition(subject => ((subject?.InnerException is null && expectation?.InnerException is null)) ||
-                    (subject?.InnerException?.GetType()?.FullName == expectation?.InnerException?.GetType()?.FullName))
-                .FailWith(
-                    "inner exception type to be {0}, but found the inner exception type to be {1}.",
-                    expectation?.InnerException?.GetType()?.FullName,
-                    Subject?.InnerException?.GetType()?.FullName)
-                .Then
-                .ForCondition(subject => subject?.InnerException?.Message == expectation?.InnerException?.Message)
-                .FailWith(
-                    "inner exception message to be {0}, but found {1}.",
-                    expectation?.InnerException?.Message,
-                    Subject?.InnerException?.Message)
-                .Then
-                .ForCondition(subject =>
-                    (subject?.InnerException?.Data is null && expectation?.InnerException?.Data is null) ||
-                        (subject?.InnerException?.Data?.Count == expectation?.InnerException?.Data?.Count))
-                .FailWith(
-                    "inner exception data to have {0} items, but found {1}.",
-                    expectation?.InnerException?.Data?.Count,
-                    Subject?.InnerException?.Data?.Count)
-                .Then
-                .ForCondition(subject => exceptionDataComparisonResult.IsEqual == true)
-                .FailWith(
-                    "exception data to match but found: "
-                    + Environment.NewLine + exceptionDataComparisonResult.Message)
-                .Then
-                .ForCondition(subject => innerExceptionDataComparisonResult.IsEqual == true)
-                .FailWith(
-                    "inner exception data to match but found: "
-                    + Environment.NewLine + innerExceptionDataComparisonResult.Message)
+                .ForCondition(subject => InnerExceptionsMatch(subject, expectation, because, becauseArgs))
+                .FailWith("to be equivalent to {0}{reason}, but it was not.", expectation)
                 .Then
                 .ClearExpectation();
 
             return new AndConstraint<XeptionAssertions<TException>>(this);
         }
+
+        private bool InnerExceptionsMatch(
+            Exception actual,
+            Exception expected,
+            string because,
+            params object[] becauseArgs)
+        {
+            if (actual == null && expected == null)
+                return true;
+
+            if (actual == null || expected == null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected exception to be {0}, but found {1}.",
+                        expected?.GetType().FullName ?? "null",
+                        actual?.GetType().FullName ?? "null");
+
+                return false;
+            }
+
+            var typeMatch = actual.GetType().FullName == expected.GetType().FullName;
+            var messageMatch = actual.Message == expected.Message;
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(typeMatch)
+
+                .FailWith(
+                    "Expected exception type to be {0}, but found {1}.",
+                    expected.GetType().FullName,
+                    actual.GetType().FullName)
+
+                .Then
+                .ForCondition(messageMatch)
+
+                .FailWith(
+                    "Expected exception message to be {0}, but found {1}.",
+                    expected.Message,
+                    actual.Message)
+
+                .Then
+                .ForCondition(ExceptionDataMatch(actual, expected, because, becauseArgs))
+                .FailWith("data to match but it does not.");
+
+            if (actual is AggregateException actualAggregate && expected is AggregateException expectedAggregate)
+            {
+                var actualInnerExceptions = actualAggregate.InnerExceptions;
+                var expectedInnerExceptions = expectedAggregate.InnerExceptions;
+
+                var countMatch = actualInnerExceptions.Count == expectedInnerExceptions.Count;
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(countMatch)
+                    .FailWith(
+                        "Expected AggregateException inner exception count to be {0}, but found {1}.",
+                        expectedInnerExceptions.Count,
+                        actualInnerExceptions.Count);
+
+                if (countMatch)
+                {
+                    for (int i = 0; i < actualInnerExceptions.Count; i++)
+                    {
+                        if (!InnerExceptionsMatch(
+                            actual: actualInnerExceptions[i],
+                            expected: expectedInnerExceptions[i],
+                            because,
+                            becauseArgs))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                return InnerExceptionsMatch(
+                    actual: actual.InnerException,
+                    expected: expected.InnerException,
+                    because, becauseArgs);
+            }
+
+            return true;
+        }
+
+        private bool ExceptionDataMatch(
+            Exception actual,
+            Exception expected,
+            string because,
+            params object[] becauseArgs)
+        {
+
+            IDictionary actualData = actual.Data;
+            IDictionary expectedData = expected.Data;
+
+            if (actualData == null && expectedData == null)
+                return true;
+
+            if (actualData == null || expectedData == null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        $"Expected exception with type '{expected.GetType().FullName}' " +
+                            $"and message '{expected.Message}' to have data as {0}, but found {1}.",
+                        expectedData?.Count == null ? "null" : "not null",
+                        actualData?.Count == null ? "null" : "not null");
+
+                return false;
+            }
+
+            StringBuilder dataSummary = new StringBuilder();
+
+            if (actualData.Count != expectedData.Count)
+            {
+                dataSummary.AppendLine(
+                    $"- have an expected data item count to be {expectedData.Count}, " +
+                    $"but found {actualData.Count}.");
+            }
+
+            foreach (var key in expectedData.Keys)
+            {
+                if (!actualData.Contains(key))
+                {
+                    dataSummary.AppendLine(
+                        $"- contain key '{key}', but it was not found.");
+                }
+            }
+
+            foreach (var key in actualData.Keys)
+            {
+                if (!expectedData.Contains(key))
+                {
+                    dataSummary.AppendLine(
+                        $"- not contain key '{key}'.");
+                }
+            }
+
+            foreach (var key in expectedData.Keys)
+            {
+                if (actualData.Contains(key))
+                {
+                    var actualValues = string.Join(", ", actualData[key] as List<string>);
+                    var expectedValues = string.Join(", ", expectedData[key] as List<string>);
+
+                    if (!Equals(actualValues, expectedValues))
+                    {
+                        dataSummary.AppendLine(
+                            $"- find key '{key}' with value(s) [{expectedValues}], " +
+                            $"but found value(s) [{actualValues}].");
+                    }
+                }
+            }
+
+            if (dataSummary.Length > 0)
+            {
+                string errorMessage = $"Expected exception with type '{expected.GetType().FullName}' " +
+                            $"and message '{expected.Message}' to:{Environment.NewLine}" +
+                            $"{dataSummary.ToString()}";
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(errorMessage);
+
+                return false;
+            }
+
+            return true;
+        }
+
 
         protected override string Identifier => "Exception";
     }

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -33,7 +33,10 @@ namespace FluentAssertions.Exceptions
                     .BecauseOf(because, becauseArgs)
                     .WithExpectation("Expected the ")
                     .Given(() => Subject)
-                    .ForCondition(subject => InnerExceptionsMatch(subject, expectation, "aggregate exception", because, becauseArgs))
+
+                    .ForCondition(subject =>
+                        InnerExceptionsMatch(subject, expectation, "aggregate exception", because, becauseArgs))
+
                     .FailWith("to be equivalent to {0}{reason}, but it was not.", expectation)
                     .Then
                     .ClearExpectation();
@@ -44,7 +47,10 @@ namespace FluentAssertions.Exceptions
                     .BecauseOf(because, becauseArgs)
                     .WithExpectation("Expected the ")
                     .Given(() => Subject)
-                    .ForCondition(subject => InnerExceptionsMatch(subject, expectation, "exception", because, becauseArgs))
+
+                    .ForCondition(subject =>
+                        InnerExceptionsMatch(subject, expectation, "exception", because, becauseArgs))
+
                     .FailWith("to be equivalent to {0}{reason}, but it was not.", expectation)
                     .Then
                     .ClearExpectation();
@@ -89,9 +95,16 @@ namespace FluentAssertions.Exceptions
 
                     .Then
                     .ForCondition(messageMatch)
-                    .FailWith($"Expected aggregate {type} message to be \"{expected.Message}\", but found \"{actual.Message}\".")
+
+                    .FailWith(
+                        $"Expected aggregate {type} message to be \"{expected.Message}\", " +
+                        $"but found \"{actual.Message}\".")
+
                     .Then
-                    .ForCondition(ExceptionDataMatch(actual, expected, "aggregate inner exception", because, becauseArgs))
+
+                    .ForCondition(
+                        ExceptionDataMatch(actual, expected, "aggregate inner exception", because, becauseArgs))
+
                     .FailWith("data to match but it does not.")
                     .Then
                     .ClearExpectation();

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -201,7 +201,7 @@ namespace FluentAssertions.Exceptions
                 return false;
             }
 
-            StringBuilder dataSummary = new StringBuilder();
+            var dataSummary = new StringBuilder();
 
             if (actualData.Count != expectedData.Count)
             {

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -66,10 +66,10 @@ namespace FluentAssertions.Exceptions
             string because,
             params object[] becauseArgs)
         {
-            if (actual == null && expected == null)
+            if (actual is null && expected is null)
                 return true;
 
-            if (actual == null || expected == null)
+            if (actual is null || expected is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -114,7 +114,7 @@ namespace FluentAssertions.Exceptions
 
                 bool countMatch = actualInnerExceptions.Count == expectedInnerExceptions.Count;
 
-                if (!countMatch)
+                if (countMatch is false)
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
@@ -132,12 +132,12 @@ namespace FluentAssertions.Exceptions
                 {
                     for (int i = 0; i < actualInnerExceptions.Count; i++)
                     {
-                        if (!InnerExceptionsMatch(
+                        if (InnerExceptionsMatch(
                             actual: actualInnerExceptions[i],
                             expected: expectedInnerExceptions[i],
                             type: $"aggregate inner exception [{i}]",
                             because,
-                            becauseArgs))
+                            becauseArgs) != true)
                         {
                             return false;
                         }
@@ -212,7 +212,7 @@ namespace FluentAssertions.Exceptions
 
             foreach (var key in expectedData.Keys)
             {
-                if (!actualData.Contains(key))
+                if (actualData.Contains(key) is false)
                 {
                     var expectedValues = String.Join(", ", expectedData[key] as List<string>);
 
@@ -223,7 +223,7 @@ namespace FluentAssertions.Exceptions
 
             foreach (var key in actualData.Keys)
             {
-                if (!expectedData.Contains(key))
+                if (expectedData.Contains(key) is false)
                 {
                     dataSummary.AppendLine(
                         $"- NOT contain key '{key}'.");
@@ -237,7 +237,7 @@ namespace FluentAssertions.Exceptions
                     var actualValues = String.Join(", ", actualData[key] as List<string>);
                     var expectedValues = String.Join(", ", expectedData[key] as List<string>);
 
-                    if (!Equals(actualValues, expectedValues))
+                    if (Equals(actualValues, expectedValues) is false)
                     {
                         dataSummary.AppendLine(
                             $"- have key '{key}' with value(s) [{expectedValues}], " +

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -80,8 +80,8 @@ namespace FluentAssertions.Exceptions
                 return false;
             }
 
-            var typeMatch = actual.GetType().FullName == expected.GetType().FullName;
-            var messageMatch = actual.Message == expected.Message;
+            bool typeMatch = actual.GetType().FullName == expected.GetType().FullName;
+            bool messageMatch = actual.Message == expected.Message;
 
             if (actual is AggregateException actualAggregate && expected is AggregateException expectedAggregate)
             {
@@ -112,7 +112,7 @@ namespace FluentAssertions.Exceptions
                 var actualInnerExceptions = actualAggregate.InnerExceptions;
                 var expectedInnerExceptions = expectedAggregate.InnerExceptions;
 
-                var countMatch = actualInnerExceptions.Count == expectedInnerExceptions.Count;
+                bool countMatch = actualInnerExceptions.Count == expectedInnerExceptions.Count;
 
                 if (!countMatch)
                 {

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -214,7 +214,7 @@ namespace FluentAssertions.Exceptions
             {
                 if (!actualData.Contains(key))
                 {
-                    var expectedValues = string.Join(", ", expectedData[key] as List<string>);
+                    var expectedValues = String.Join(", ", expectedData[key] as List<string>);
 
                     dataSummary.AppendLine(
                         $"- contain key '{key}' with value(s) [{expectedValues}].");
@@ -234,8 +234,8 @@ namespace FluentAssertions.Exceptions
             {
                 if (actualData.Contains(key))
                 {
-                    var actualValues = string.Join(", ", actualData[key] as List<string>);
-                    var expectedValues = string.Join(", ", expectedData[key] as List<string>);
+                    var actualValues = String.Join(", ", actualData[key] as List<string>);
+                    var expectedValues = String.Join(", ", expectedData[key] as List<string>);
 
                     if (!Equals(actualValues, expectedValues))
                     {

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -261,7 +261,6 @@ namespace FluentAssertions.Exceptions
             return true;
         }
 
-
         protected override string Identifier => "Exception";
     }
 }

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -80,8 +80,8 @@ namespace Xeptions
             StringBuilder messageStringBuilder = new StringBuilder();
             isEqual = CompareDataKeys(dictionary, isEqual, messageStringBuilder);
 
-            string errorMessage = string.IsNullOrWhiteSpace(messageStringBuilder.ToString())
-                ? string.Empty
+            string errorMessage = String.IsNullOrWhiteSpace(messageStringBuilder.ToString())
+                ? String.Empty
                 : $"Expected data to: {Environment.NewLine}{messageStringBuilder.ToString()}";
 
             return (isEqual, errorMessage);
@@ -144,7 +144,7 @@ namespace Xeptions
 
                 foreach (DictionaryEntry dictionaryEntry in missingItems)
                 {
-                    var values = string.Join(", ", dictionaryEntry.Value as List<string>);
+                    var values = String.Join(", ", dictionaryEntry.Value as List<string>);
 
                     AppendMessage(
                         messageStringBuilder,
@@ -222,7 +222,7 @@ namespace Xeptions
 
         private void AppendMessage(StringBuilder builder, string message)
         {
-            if (!string.IsNullOrEmpty(message))
+            if (!String.IsNullOrEmpty(message))
             {
                 builder.AppendLine(message);
             }

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -222,7 +222,7 @@ namespace Xeptions
 
         private void AppendMessage(StringBuilder builder, string message)
         {
-            if (!String.IsNullOrEmpty(message))
+            if (String.IsNullOrEmpty(message) is false)
             {
                 builder.AppendLine(message);
             }

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -77,7 +77,7 @@ namespace Xeptions
         public (bool IsEqual, string Message) DataEqualsWithDetail(IDictionary dictionary)
         {
             bool isEqual = true;
-            StringBuilder messageStringBuilder = new StringBuilder();
+            var messageStringBuilder = new StringBuilder();
             isEqual = CompareDataKeys(dictionary, isEqual, messageStringBuilder);
 
             string errorMessage = String.IsNullOrWhiteSpace(messageStringBuilder.ToString())

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -80,7 +80,11 @@ namespace Xeptions
             StringBuilder messageStringBuilder = new StringBuilder();
             isEqual = CompareDataKeys(dictionary, isEqual, messageStringBuilder);
 
-            return (isEqual, messageStringBuilder.ToString());
+            string errorMessage = string.IsNullOrWhiteSpace(messageStringBuilder.ToString())
+                ? string.Empty
+                : $"Expected data to: {Environment.NewLine}{messageStringBuilder.ToString()}";
+
+            return (isEqual, errorMessage);
         }
 
         private bool CompareDataKeys(IDictionary dictionary, bool isEqual, StringBuilder messageStringBuilder)
@@ -96,7 +100,7 @@ namespace Xeptions
 
                 AppendMessage(
                     messageStringBuilder,
-                    $"- Expected data item count to be {dictionary.Count}, but found {this.Data.Count}.");
+                    $"- have a count of {dictionary.Count}, but found {this.Data.Count}.");
             }
 
             (IDictionary additionalItems, IDictionary missingItems, IDictionary sharedItems) =
@@ -122,7 +126,7 @@ namespace Xeptions
                 {
                     AppendMessage(
                         messageStringBuilder,
-                        $"- Did not expect to find key '{dictionaryEntry.Key}'.");
+                        $"- NOT contain key '{dictionaryEntry.Key}'.");
                 }
             }
 
@@ -140,9 +144,11 @@ namespace Xeptions
 
                 foreach (DictionaryEntry dictionaryEntry in missingItems)
                 {
+                    var values = string.Join(", ", dictionaryEntry.Value as List<string>);
+
                     AppendMessage(
                         messageStringBuilder,
-                        $"- Expected to find key '{dictionaryEntry.Key}'.");
+                        $"- contain key '{dictionaryEntry.Key}' with value(s) [{values}].");
                 }
             }
 
@@ -171,7 +177,7 @@ namespace Xeptions
 
                         AppendMessage(
                             messageStringBuilder,
-                            $"- Expected to find key '{dictionaryEntry.Key}' " +
+                            $"- have key '{dictionaryEntry.Key}' " +
                             $"with value(s) ['{expectedValues}'], " +
                             $"but found value(s) ['{actualValues}'].");
                     }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -40,6 +40,7 @@ namespace Xeptions
             catch (Exception error)
             {
                 message = error.Message;
+
                 return false;
             }
         }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -35,7 +35,7 @@ namespace Xeptions
             try
             {
                 exception.Should().BeEquivalentTo(otherException);
-                message = string.Empty;
+                message = String.Empty;
 
                 return true;
             }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------------
 
 using System;
-using System.Linq.Expressions;
+using FluentAssertions;
 
 namespace Xeptions
 {
@@ -17,18 +17,30 @@ namespace Xeptions
 
         public static bool SameExceptionAs(this Exception exception, Exception otherException)
         {
-            return
-                (exception is null && otherException is null) ||
-                (exception?.GetType()?.FullName == otherException?.GetType()?.FullName
-                && exception?.Message == otherException?.Message
-                && ((Xeption)exception).DataEquals(otherException?.Data)
-                && ((exception?.InnerException is null && otherException?.InnerException is null) ||
-                (exception?.InnerException?.GetType()?.FullName == otherException?.InnerException?.GetType()?.FullName
-                && exception?.InnerException?.Message == otherException?.InnerException?.Message
-                && ((Xeption)(exception?.InnerException)).DataEquals(otherException?.InnerException?.Data))));
+            try
+            {
+                exception.Should().BeEquivalentTo(otherException);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
-        public static Expression<Func<Exception, bool>> SameExceptionAs(Exception expectedException) =>
-            actualException => actualException.SameExceptionAs(expectedException);
+        public static bool SameExceptionAs(this Exception exception, Exception otherException, out string message)
+        {
+            try
+            {
+                exception.Should().BeEquivalentTo(otherException);
+                message = string.Empty;
+                return true;
+            }
+            catch (Exception error)
+            {
+                message = error.Message;
+                return false;
+            }
+        }
     }
 }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Linq.Expressions;
 using FluentAssertions;
 
 namespace Xeptions
@@ -42,5 +43,8 @@ namespace Xeptions
                 return false;
             }
         }
+
+        public static Expression<Func<Exception, bool>> SameExceptionAs(Exception expectedException) =>
+            actualException => actualException.SameExceptionAs(expectedException);
     }
 }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -42,7 +42,7 @@ namespace Xeptions
             catch (Exception error)
             {
                 message = error.Message;
-
+                
                 return false;
             }
         }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -21,6 +21,7 @@ namespace Xeptions
             try
             {
                 exception.Should().BeEquivalentTo(otherException);
+
                 return true;
             }
             catch (Exception)
@@ -35,6 +36,7 @@ namespace Xeptions
             {
                 exception.Should().BeEquivalentTo(otherException);
                 message = string.Empty;
+
                 return true;
             }
             catch (Exception error)


### PR DESCRIPTION
This change adds support for:

- Fluent assertion now consider all levels of inner exceptions and not just the 1st two,
- Fluent assertion now also consider `InnerExceptions` that are specific to aggregate exceptions
- SameExceptionAs now has an overload method that will give you the error details.   This is very handy to spot object differences on mock Verify checks

To make use of this you can make the following change in the test:
```cs
            this.loggingBrokerMock.Verify(broker =>
                broker.LogError(It.Is(
                    SameExceptionAs(expectedSourceValidationException, "loggingBrokerMock.Verify", output))),
                        Times.Once);
```

Modify the `SameExceptionAs` in the main test file to now call a new method `IsSameExceptionAs`  This method will do the same comparison, but make use of the SameExceptionAs overload so that we can get the error details.  If any error details are found, it will now be visible in the Test Explorer windows as part of the test result.
```cs
        private static Expression<Func<Xeption, bool>> SameExceptionAs(
            Xeption expectedException, string prefix, ITestOutputHelper output) =>
                actualException => IsSameExceptionAs(actualException, expectedException, prefix, output);

        private static bool IsSameExceptionAs(
            Xeption actualException,
            Xeption expectedException,
            string prefix,
            ITestOutputHelper output)
        {
            var result = actualException.SameExceptionAs(expectedException, out string message);

            if (!string.IsNullOrWhiteSpace(message))
            {
                if (!string.IsNullOrEmpty(prefix))
                {
                    output.WriteLine($"{prefix}: {message}");
                }
                else
                {
                    output.WriteLine(message);
                }
            }

            return result;
        }
```
![image](https://github.com/user-attachments/assets/b3bc3358-500e-4fd1-b4b0-3c750c9e4ccf)
